### PR TITLE
Support executing test files to run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+sudo: required
+dist: trusty
+
 language: node_js
 node_js:
-- '0.10'
+  - 4.2.6

--- a/package.json
+++ b/package.json
@@ -33,16 +33,12 @@
     "babel-plugin-add-module-exports": "^0.1.2",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
-    "bluebird": "^3.4.5",
-    "chai": "^3.5.0",
-    "eslint": "^2.7.0",
-    "eslint-plugin-goodeggs": "^1.4.0",
-    "goodeggs-domain-events": "^12.4.0",
-    "goodeggs-stats": "^4.4.2",
+    "eslint": "~3.1.1",
+    "eslint-plugin-goodeggs": "^3.3.1",
+    "eslint-plugin-lodash": "^1.10.3",
+    "eslint-plugin-mocha": "^4.5.1",
     "in-publish": "^2.0.0",
-    "mocha": "^2.4.5",
-    "sinon": "^1.17.5",
-    "unionized": "^4.10.1"
+    "mocha": "^2.4.5"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "main": "index.js",
   "author": "Good Eggs Inc.",
   "contributors": [
-    "dannynelson <danny@goodeggs.com>"
+    "dannynelson <danny@goodeggs.com>",
+    "max edmands <max@goodeggs.com>"
   ],
-  "license": "Private",
+  "license": "UNLICENSED",
   "engines": {
     "node": ">=4"
   },
@@ -23,7 +24,6 @@
     "chaid": "^1.0.2",
     "dirty-chai": "^1.2.2",
     "geomoment": "*",
-    "kexec": "^1.3.0",
     "lodash.isfunction": "^3.0.8",
     "sinon": "^1.14.1",
     "sinon-chai": "^2.7.0"
@@ -57,8 +57,11 @@
     "prepublish": "./can_publish",
     "postpublish": "npm cache clean",
     "lint": "eslint 'src/**/*.js'  --ignore-path .gitignore",
-    "test:mocha": "NODE_ENV=test mocha --compilers=js:babel-register --require=babel-polyfill 'test/test.js'",
-    "test": "npm run lint && npm run test:mocha --"
+    "test:mocha": "NODE_ENV=test mocha --compilers=js:babel-register",
+    "test:mocha:all": "npm run test:mocha -- 'test/*.js'",
+    "test:single": "npm run test:mocha -- __TESTFILE__",
+    "test:watch:single": "npm run test:mocha -- --watch __TESTFILE__",
+    "test": "npm run lint && npm run test:mocha:all --"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/src/exec_file_as_test.js
+++ b/src/exec_file_as_test.js
@@ -1,0 +1,51 @@
+if (!global.describe) {
+  function errExit (message, code = 1) { // eslint-disable-line no-inner-declarations
+    process.stderr.write(`${message}\n`);
+    process.exit(code);
+  }
+
+  const cp = require('child_process'); // eslint-disable-line global-require
+  const fs = require('fs'); // eslint-disable-line global-require
+  const path = require('path'); // eslint-disable-line global-require
+
+  const script = process.argv[1];
+  const watch = (process.argv[2] === '--watch' || process.argv[2] === '-w');
+
+  // find the nearest package.json
+  let pkgPath = process.cwd();
+  let pkgJsonFile = null;
+  let pkgJson = null;
+  while (pkgJson === null && path.dirname(pkgPath) !== pkgPath) {
+    try {
+      pkgJsonFile = path.join(pkgPath, 'package.json');
+      pkgJson = JSON.parse(fs.readFileSync(pkgJsonFile, {encoding: 'utf8'})); // eslint-disable-line no-sync
+    } catch (e) {
+      pkgPath = path.dirname(pkgPath);
+    }
+  }
+  if (pkgJson === null) errExit('Could not find a package.json in the current directory or any parent directories.');
+  if (pkgJson.scripts === undefined) errExit(`${pkgJsonFile} does not have a scripts section; cannot run test.`);
+
+  // figure out what command to run
+  const scriptName = watch ? 'test:watch:single' : 'test:single';
+  if (pkgJson.scripts[scriptName] === undefined) errExit(`${pkgJsonFile} does not have a '${scriptName}' script; cannot run test.`);
+  let command = pkgJson.scripts[scriptName].replace('__TESTFILE__', script);
+
+  // hack to support nsrun (https://github.com/demands/nsrun)
+  try {
+    // check to see if nsrun exists in $PATH:
+    cp.execSync('nsrun'); // eslint-disable-line no-sync
+    command = command.replace(/npm run/g, 'nsrun');
+  } catch (e) { /* noop */ }
+
+  const env = Object.assign({}, process.env, {
+    PATH: `${path.join(pkgPath, 'node_modules', '.bin')}:${process.env.PATH}`,
+  });
+
+  try {
+    cp.execSync(command, {env, stdio: 'inherit'}); // eslint-disable-line no-sync
+  } catch (e) {
+    process.exit(e.status);
+  }
+  process.exit(0);
+}

--- a/src/globals.js
+++ b/src/globals.js
@@ -7,16 +7,16 @@ import sinon from 'sinon';
 
 // semantic proxy. includes subs like `skip`.
 const givenDescription = (description) => `given ${description}`;
-GLOBAL.given = function given (description, callback) {
+global.given = function given (description, callback) {
   return describe(givenDescription(description), callback);
 };
 Object.keys(describe).forEach(function (attr) {
-  GLOBAL.given[attr] = function given (description, callback) {
+  global.given[attr] = function given (description, callback) {
     return describe[attr](givenDescription(description), callback);
   };
 });
 
-GLOBAL.withContext = function (attribute, promiseFn) {
+global.withContext = function (attribute, promiseFn) {
   return beforeEach(`setting context ${attribute}`, function () {
     let promise = promiseFn;
     if (isFunction(promiseFn)) promise = promiseFn.call(this); // eslint-disable-line
@@ -29,5 +29,5 @@ GLOBAL.withContext = function (attribute, promiseFn) {
   });
 };
 
-GLOBAL.expect = chai.expect;
-GLOBAL.sinon = sinon;
+global.expect = chai.expect;
+global.sinon = sinon;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
-import './chai_config';
+import './exec_file_as_test'; // this has to be first
+
+import './chai_config'; // eslint-disable-line goodeggs/group-imports
 import './mocha_context.js';
 import './globals';

--- a/test/exec_file_as_test.js
+++ b/test/exec_file_as_test.js
@@ -1,0 +1,25 @@
+/* eslint-env goodeggs/server-side-test */
+import '../src';
+
+import cp from 'child_process';
+import path from 'path';
+
+describe('exec_file_as_test', function () {
+  it('allows you to run a js file and have it interpereted as a test', function (done) {
+    this.timeout(5000);
+
+    const file = path.join(__dirname, 'simpletest.js');
+    const proc = cp.spawn('babel-node', [file]);
+    let seenMagicalText = false;
+    proc.stderr.pipe(process.stderr);
+    proc.stdout.on('data', function (d) {
+      if (d.toString('utf8').match(/does not test anything in particular/))
+        seenMagicalText = true;
+    });
+    proc.on('close', function (code) {
+      if (code !== 0) return done(new Error(`\`babel-node simpletest.js\` exited with code ${code}.`));
+      if (!seenMagicalText) return done(new Error('`babel-node simpletest.js\` did not run in a mocha context.'));
+      return done();
+    });
+  });
+});

--- a/test/simpletest.js
+++ b/test/simpletest.js
@@ -1,0 +1,6 @@
+/* eslint-env goodeggs/server-side-test */
+import '../src';
+
+describe('simple test', function () {
+  it('does not test anything in particular, but is used by exec_file_as_test.js', function () {});
+});

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,4 @@
 /* eslint-env goodeggs/server-side-test */
-
 import '../src';
 
 import Promise from 'bluebird';


### PR DESCRIPTION
Now you should be able to `node` (or `babel-node`) your test files, and it should run the tests in the file that you executed.

This requires including a `test:single` script in your `package.json` file, so that we know how your app prefers to run its tests.

Additionally, you can pass a --watch argument when you're executing a test file, and it'll run the `test:watch:single` script instead.