### PR TITLE
Support karma tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
   "name": "goodeggs-test-helpers",
   "version": "1.1.1",
   "description": "Basic setup used for all goodeggs tests.",
-  "main": "index.js",
+  "main": "server.js",
+  "browser": {
+    "./server.js": "./browser.js",
+    "sinon": "./sinon_webpack_shim.js",
+    "./global.js": "./global_browser_shim.js"
+  },
   "author": "Good Eggs Inc.",
   "contributors": [
     "dannynelson <danny@goodeggs.com>",
@@ -53,11 +58,11 @@
     "prepublish": "./can_publish",
     "postpublish": "npm cache clean",
     "lint": "eslint 'src/**/*.js'  --ignore-path .gitignore",
-    "test:mocha": "NODE_ENV=test mocha --compilers=js:babel-register",
-    "test:mocha:all": "npm run test:mocha -- 'test/*.js'",
-    "test:single": "npm run test:mocha -- __TESTFILE__",
-    "test:watch:single": "npm run test:mocha -- --watch __TESTFILE__",
-    "test": "npm run lint && npm run test:mocha:all --"
+    "test:mocha": "npm run build && NODE_ENV=test mocha --compilers=js:babel-register",
+    "test:mocha:all": "npm run build && npm run test:mocha -- 'test/*.js'",
+    "test:single": "npm run build && npm run test:mocha -- __TESTFILE__",
+    "test:watch:single": "npm run build && npm run test:mocha -- --watch __TESTFILE__",
+    "test": "npm run build && npm run lint && npm run test:mocha:all --"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,1 @@
+import './index';

--- a/src/chai.js
+++ b/src/chai.js
@@ -10,3 +10,6 @@ chai.use(dirtyChai);
 chai.use(sinonChai);
 chai.use(chaid);
 chai.use(chaiDateTime);
+
+// To add more chai plugins, require chai from this file.
+export default chai;

--- a/src/global.js
+++ b/src/global.js
@@ -1,0 +1,1 @@
+export default global; // eslint-disable-line

--- a/src/global_browser_shim.js
+++ b/src/global_browser_shim.js
@@ -1,0 +1,1 @@
+export default window; // eslint-disable-line

--- a/src/globals.js
+++ b/src/globals.js
@@ -5,18 +5,20 @@ import chai from 'chai';
 import isFunction from 'lodash.isfunction';
 import sinon from 'sinon';
 
+import globalVar from './global';
+
 // semantic proxy. includes subs like `skip`.
 const givenDescription = (description) => `given ${description}`;
-global.given = function given (description, callback) {
+globalVar.given = function given (description, callback) {
   return describe(givenDescription(description), callback);
 };
 Object.keys(describe).forEach(function (attr) {
-  global.given[attr] = function given (description, callback) {
+  globalVar.given[attr] = function given (description, callback) {
     return describe[attr](givenDescription(description), callback);
   };
 });
 
-global.withContext = function (attribute, promiseFn) {
+globalVar.withContext = function (attribute, promiseFn) {
   return beforeEach(`setting context ${attribute}`, function () {
     let promise = promiseFn;
     if (isFunction(promiseFn)) promise = promiseFn.call(this); // eslint-disable-line
@@ -29,5 +31,5 @@ global.withContext = function (attribute, promiseFn) {
   });
 };
 
-global.expect = chai.expect;
-global.sinon = sinon;
+globalVar.expect = chai.expect;
+globalVar.sinon = sinon;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-import './exec_file_as_test'; // this has to be first
-
-import './chai_config'; // eslint-disable-line goodeggs/group-imports
 import './mocha_context.js';
 import './globals';
+import './chai';

--- a/src/server.js
+++ b/src/server.js
@@ -1,0 +1,2 @@
+import './exec_file_as_test'; // this has to be first
+import './index';

--- a/src/sinon_webpack_shim.js
+++ b/src/sinon_webpack_shim.js
@@ -1,0 +1,4 @@
+// importing sinon causes a webpack error:
+// instead, attach to window via karma-sinon, and require from here :(
+// https://github.com/webpack/webpack/issues/304
+export default window.sinon; // eslint-disable-line

--- a/test/exec_file_as_test.js
+++ b/test/exec_file_as_test.js
@@ -1,5 +1,5 @@
 /* eslint-env goodeggs/server-side-test */
-import '../src';
+import '../build';
 
 import cp from 'child_process';
 import path from 'path';
@@ -7,7 +7,6 @@ import path from 'path';
 describe('exec_file_as_test', function () {
   it('allows you to run a js file and have it interpereted as a test', function (done) {
     this.timeout(100000);
-
     const file = path.join(__dirname, 'simpletest.js');
     const proc = cp.spawn('babel-node', [file]);
     let seenMagicalText = false;

--- a/test/simpletest.js
+++ b/test/simpletest.js
@@ -1,5 +1,5 @@
 /* eslint-env goodeggs/server-side-test */
-import '../src';
+import '../build';
 
 describe('simple test', function () {
   it('does not test anything in particular, but is used by exec_file_as_test.js', function () {});

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,5 @@
 /* eslint-env goodeggs/server-side-test */
-import '../src';
+import '../build';
 
 import Promise from 'bluebird';
 import geomoment from 'geomoment';


### PR DESCRIPTION
- shim `sinon` so that it does not break webpack
- use `window` as the global when available

Note, this allows us to run individual karma tests with `babel-node path/to/file --watch` 😄 .