### PR TITLE
Add support for Facebook's Flow library.

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,7 @@
+[ignore]
+
+[include]
+
+[libs]
+
+[options]

--- a/package.json
+++ b/package.json
@@ -35,13 +35,16 @@
   },
   "devDependencies": {
     "babel-cli": "^6.6.5",
+    "babel-eslint": "^6.1.2",
     "babel-plugin-add-module-exports": "^0.1.2",
+    "babel-plugin-transform-flow-strip-types": "^6.14.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-register": "^6.7.2",
     "eslint": "~3.1.1",
     "eslint-plugin-goodeggs": "^3.3.1",
     "eslint-plugin-lodash": "^1.10.3",
     "eslint-plugin-mocha": "^4.5.1",
+    "flow-bin": "^0.32.0",
     "in-publish": "^2.0.0",
     "mocha": "^2.4.5"
   },
@@ -50,7 +53,8 @@
       "es2015"
     ],
     "plugins": [
-      "add-module-exports"
+      "add-module-exports",
+      "transform-flow-strip-types"
     ]
   },
   "scripts": {
@@ -69,6 +73,7 @@
     "always-auth": true
   },
   "eslintConfig": {
+    "parser": "babel-eslint",
     "plugins": [
       "goodeggs"
     ],

--- a/src/flow.js
+++ b/src/flow.js
@@ -1,0 +1,13 @@
+/* eslint-disable no-unused-vars */
+
+declare function describe(title: string, fn: () => void): void;
+declare function given(title: string, fn: () => void): void;
+
+declare function before(title?: string, fn: (cb?:(err?:Error) => void) => mixed): void;
+declare function beforeEach(title?: string, fn: (cb?:(err?:Error) => void) => mixed): void;
+declare function after(title?: string, fn: (cb?:(err?:Error) => void) => mixed): void;
+declare function afterEach(title?: string, fn: (cb?:(err?:Error) => void) => mixed): void;
+
+declare function it(title: string, fn?: (cb?:(err?:Error) => void) => mixed): void;
+
+declare function expect(thing: mixed): any;


### PR DESCRIPTION
[See more about Flow.](https://flowtype.org)

This PR exports a file of global declarations, that you can point to from the `[libs]` section of your app's `.flowconfig` file, so that Flow will understand our test globals (`describe`, `it`, `expect`, etc.).

Here's an example `.flowconfig` file, showing how you might use this helper:

```
[ignore]
build/*
.coverage/*

[include]

[libs]
node_modules/goodeggs-test-helpers/flow

[options]
module.name_mapper='local_modules/' -> '<PROJECT_ROOT>/local_modules/'
```