### PR TITLE
Restore stubLogger interface

### DIFF
--- a/src/use_sinon_sandbox.js
+++ b/src/use_sinon_sandbox.js
@@ -23,7 +23,7 @@ export default function useSinonSandbox () {
       return date;
     };
 
-    this.stubLogger = function ({logger} = {}) {
+    this.stubLogger = function (logger) {
       assert(logger != null, 'logger required');
       this.stub(logger, 'trace');
       this.stub(logger, 'debug');

--- a/test/test.js
+++ b/test/test.js
@@ -69,7 +69,7 @@ describe('mocha helpers', function () {
 
     it('can stub logger', function () {
       const logger = bunyan.createLogger({name: 'myapp'});
-      this.stubLogger({logger});
+      this.stubLogger(logger);
       logger.info('foo bar');
       expect(logger.info).to.have.been.calledOnce();
     });


### PR DESCRIPTION
`this.stubLogger(logger);` is more intuitive and matches the previous interface in `goodeggs-test-helpers` v3.