### PR TITLE
Export chai so consumers can use additional plugins.

### DIFF
--- a/src/browser.js
+++ b/src/browser.js
@@ -1,4 +1,7 @@
 // @flow
+import chai from './chai';
+
+const {expect} = chai;
+export {expect, chai};
 export {default as sinon} from 'sinon';
 export {default as useSinonSandbox} from './use_sinon_sandbox';
-export {expect} from './chai';

--- a/src/chai.js
+++ b/src/chai.js
@@ -12,5 +12,4 @@ chai.use(sinonChai);
 chai.use(chaid);
 chai.use(chaiDateTime);
 
-const expect = chai.expect; // eslint-disable-line goodeggs/import-no-named-as-default-member
-export {expect};
+export default chai;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 // @flow
 // TODO, ideally we would export {desribe, it} etc from mocha.
 // But those are not available when imported into thirdparty dependencies :(
+import chai from './chai';
+
+const {expect} = chai;
+export {expect, chai};
 export {default as sinon} from 'sinon';
-export {expect} from './chai';
 export {default as useSinonSandbox} from './use_sinon_sandbox';

--- a/test/other_test.js
+++ b/test/other_test.js
@@ -1,7 +1,7 @@
 // @flow
 import {describe, it} from 'mocha';
 
-import {expect} from '../';
+import {expect} from '../lib';
 
 describe('other', function () {
   it('works', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import {describe, beforeEach, it} from 'mocha';
 import dateTestHelpers from 'date-test-helpers';
 import bunyan from 'bunyan';
 
-import {expect, useSinonSandbox, sinon} from '../';
+import {expect, useSinonSandbox, sinon} from '../lib';
 
 describe('mocha helpers', function () {
   describe('chai expect', function () {


### PR DESCRIPTION
(Also make it clear that we're testing built code, and avoid confusing flow errors before building.)