### PR TITLE
Improve sinon usage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+node_modules
+lib
+*.log
+.coverage
+flow-typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [6.0.0](https://github.com/goodeggs/goodeggs-test-helpers/compare/v5.1.0...v6.0.0)
+
+### BREAKING CHANGES
+- `useSinonSandbox()` returns a `{sandbox, stubLogger}`
+- `this.stub` => `sandbox.stub`
+- `this.spy` => `sandbox.spy`
+- `const clock = sandbox.useFakeTimers()` to mock time
+- `this.stubTime()` => `clock.setSystemTime()`
+- `this.stubLogger()` => `stubLogger()`
+- `sinon.match()` => `sandbox.match()`
+- sinon no longer exported. Use `sandbox` from `{useSinonSandbox}` instead
+
 # [5.1.3](https://github.com/goodeggs/goodeggs-test-helpers/compare/v5.1.2...v5.1.3)
 
 - Fix flowtype definitions

--- a/package.json
+++ b/package.json
@@ -63,10 +63,10 @@
     "build": "rm -rf lib/ && babel src -d lib && cp src/index.js.flow lib/",
     "prepublishOnly": "yarn build",
     "lint": "eslint 'src/**/*.js'  --ignore-path .gitignore",
-    "test:mocha": "npm run build && ./runtest.sh",
-    "test:watch": "npm run build && ./runtest.sh --watch",
-    "test:coverage": "npm run build && ./runtest.sh --coverage",
-    "test": "npm run lint && npm run test:mocha"
+    "test:mocha": "./runtest.sh",
+    "test:watch": "./runtest.sh --watch",
+    "test:coverage": "./runtest.sh --coverage",
+    "test": "yarn run lint && flow && npm run test:mocha"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/src/index.js
+++ b/src/index.js
@@ -5,5 +5,4 @@ import chai from './chai';
 
 const {expect} = chai;
 export {expect, chai};
-export {default as sinon} from 'sinon';
 export {default as useSinonSandbox} from './use_sinon_sandbox';

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,7 +1,5 @@
 // @flow
 
-declare export function useSinonSandbox (): void;
-
 // -------------------------------------------------
 // copied from flow-typed/chai and monkey-patched
 // -------------------------------------------------
@@ -282,7 +280,7 @@ declare class Assert {
 
   // chai-immutable
   static sizeOf(val: mixed, length: number): void;
-};
+}
 
 declare export var chai: {
   expect: <T>(actual: T, message?: string) => ExpectChain<T>,
@@ -497,8 +495,8 @@ declare interface SinonFakeTimers {
 
 declare interface SinonFakeTimersStatic {
   (): SinonFakeTimers;
-  (...timers: string[]): SinonFakeTimers;
-  (now: number, ...timers: string[]): SinonFakeTimers;
+  (now: number): SinonFakeTimers;
+  (config: {|+now?: number, +toFake?: Array<string>, +shouldAdvanceTime?: boolean|}): SinonFakeTimers;
 }
 
 declare interface SinonFakeUploadProgress {
@@ -706,8 +704,10 @@ declare interface SinonSandbox {
   spy: SinonSpyStatic;
   stub: SinonStubStatic;
   mock: SinonMockStatic;
+  match: SinonMatch;
   useFakeTimers: SinonFakeTimersStatic;
   useFakeXMLHttpRequest: SinonFakeXMLHttpRequestStatic;
+  useFakeTimers(): SinonFakeTimersStatic;
   useFakeServer(): SinonFakeServer;
   restore(): void;
   reset(): void;
@@ -731,7 +731,7 @@ declare interface SinonTestConfig {
   useFakeServer?: boolean;
 }
 
-declare export var sinon: {
+declare var sinon: {
   spy: SinonSpyStatic;
   stub: SinonStubStatic;
   expectation: SinonExpectationStatic;
@@ -753,3 +753,15 @@ declare export var sinon: {
   log(message: string): void;
   restore(object: any): void;
 };
+
+interface Logger {
+  trace(...*): mixed;
+  debug(...*): mixed;
+  info(...*): mixed;
+  warn(...*): mixed;
+  error(...*): mixed;
+  fatal(...*): mixed;
+  child(...*): mixed;
+}
+
+declare export function useSinonSandbox (): {|+sandbox: SinonSandbox, stubLogger: (logger: Logger) => void|};

--- a/src/use_sinon_sandbox.js
+++ b/src/use_sinon_sandbox.js
@@ -4,39 +4,22 @@ import sinon from 'sinon';
 import assert from 'assert';
 
 export default function useSinonSandbox () {
-  beforeEach('use sinon sandbox', function () {
-    this.sinon = sinon.sandbox.create({
-      injectInto: this,
-      properties: ['spy', 'stub', 'mock'],
-      useFakeTimers: false,
-      useFakeServer: false,
-    });
+  const sandbox = sinon.createSandbox();
 
-    const clock = this.clock = this.sinon.useFakeTimers({
-      now: 0,
-      toFake: ['Date'],
-    });
-
-    this.stubTime = function stubTime (date) {
-      assert(date != null, 'date required');
-      clock.setSystemTime(date);
-      return date;
-    };
-
-    this.stubLogger = function (logger) {
-      assert(logger != null, 'logger required');
-      this.stub(logger, 'trace');
-      this.stub(logger, 'debug');
-      this.stub(logger, 'info');
-      this.stub(logger, 'warn');
-      this.stub(logger, 'error');
-      this.stub(logger, 'fatal');
-      this.stub(logger, 'child').returns(logger);
-    }.bind(this);
-  });
+  const stubLogger = (logger: Object) => {
+    assert(logger != null, 'logger required');
+    sandbox.stub(logger, 'trace');
+    sandbox.stub(logger, 'debug');
+    sandbox.stub(logger, 'info');
+    sandbox.stub(logger, 'warn');
+    sandbox.stub(logger, 'error');
+    sandbox.stub(logger, 'fatal');
+    sandbox.stub(logger, 'child').returns(logger);
+  };
 
   afterEach('restore sinon sandbox', function () {
-    this.clock.restore();
-    this.sinon.restore();
+    sandbox.restore();
   });
+
+  return {sandbox, stubLogger};
 }

--- a/test/other_test.js
+++ b/test/other_test.js
@@ -1,7 +1,7 @@
 // @flow
 import {describe, it} from 'mocha';
 
-import {expect} from '../lib';
+import {expect} from '../src';
 
 describe('other', function () {
   it('works', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -3,7 +3,7 @@ import {describe, beforeEach, it} from 'mocha';
 import dateTestHelpers from 'date-test-helpers';
 import bunyan from 'bunyan';
 
-import {expect, useSinonSandbox, sinon} from '../lib';
+import {expect, useSinonSandbox} from '../src';
 
 describe('mocha helpers', function () {
   describe('chai expect', function () {
@@ -34,7 +34,7 @@ describe('mocha helpers', function () {
   });
 
   describe('useSinonSandbox()', function () {
-    useSinonSandbox();
+    const {sandbox, stubLogger} = useSinonSandbox();
 
     beforeEach('create an object with methods', function () {
       this.foo = {
@@ -43,7 +43,7 @@ describe('mocha helpers', function () {
     });
 
     it('has a sinon sandbox and sinon-chai', function () {
-      this.stub(this.foo, 'bar');
+      sandbox.stub(this.foo, 'bar');
       this.foo.bar();
       expect(this.foo.bar).to.have.been.called();
     });
@@ -52,34 +52,27 @@ describe('mocha helpers', function () {
       expect();
     });
 
-    it('stubs the clock to the beginning of the UNIX epoch by default', function () {
+    it('can stub the clock', function () {
+      sandbox.useFakeTimers({now: 0});
       expect(Date.now()).to.equal(0);
     });
 
-    it('can change the time with this.stubTime()', function () {
+    it('can change the time with clock.setSystemTime()', function () {
+      const clock = sandbox.useFakeTimers({now: 0});
       const time = dateTestHelpers.pacific.time('2012-11-22 00:00:00');
-      this.stubTime(time);
+      clock.setSystemTime(time);
       expect(Date.now()).to.equal(time.valueOf());
-    });
-
-    it('will return whatever got passed into this.stubTime()', function () {
-      const date = new Date(200);
-      expect(this.stubTime(date)).to.equal(date);
     });
 
     it('can stub logger', function () {
       const logger = bunyan.createLogger({name: 'myapp'});
-      this.stubLogger(logger);
+      stubLogger(logger);
       logger.info('foo bar');
       expect(logger.info).to.have.been.calledOnce();
     });
-  });
 
-  describe('sinon', function () {
-    it('can use', function () {
-      const foo = {bar: sinon.stub()};
-      foo.bar();
-      expect(foo.bar).to.have.been.calledOnce();
+    it('can use matchers', function () {
+      expect(sandbox.match).to.be.a('function');
     });
   });
 });


### PR DESCRIPTION
The `useSinonSandbox()` interface had several problems:
- You could not mock time independently of creating a sinon sandbox
- You could not modify the args for `sinon.useFakeTimers` (e.g. for mocking `setInterval`)
- all `useSinonSandbox` methods on `this` were not covered by flow

Changes:
- `useSinonSandbox()` returns a `{sandbox, stubLogger}`
- `this.stub` => `sandbox.stub`
- `this.spy` => `sandbox.spy`
- `const clock = sandbox.useFakeTimers()` to mock time
- `this.stubTime()` => `clock.setSystemTime()`
- `this.stubLogger()` => `stubLogger()`
- `sinon.match()` => `sandbox.match()`

So new interface looks like this:
```js
import {useSinonSandbox} from 'goodeggs-test-helpers';

describe('sandbox test', function () {
  const {sandbox, stubLogger} = useSinonSandbox();

  it('does a thing', function () {
    const clock = sandbox.useFakeTimers();
    clock.setSystemTime(300);
    sandbox.stub(foo, 'bar');
    sandbox.spy(foo, 'baz');
    stubLogger(logger);
    expect(foo.bar).to.have.been.calledOn(sandbox.match({foo: 'bar'}))
  });
});
```