### PR TITLE
Fix flowtype definition

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,5 +1,4 @@
 // @flow
-// flow gen-flow-files did not work :(
 
 declare export function useSinonSandbox (): void;
 
@@ -152,151 +151,155 @@ declare type ExpectChain<T> = {
 
 declare export function expect<T>(actual: T, message?: string): ExpectChain<T>;
 
-declare function use(plugin: (chai: Object, utils: Object) => void): void;
+declare export var chai: {
+  declare function expect<T>(actual: T, message?: string): ExpectChain<T>;
 
-declare class assert {
-  static (expression: mixed, message?: string): void;
-  static fail(
-    actual: mixed,
-    expected: mixed,
-    message?: string,
-    operator?: string
-  ): void;
+  declare function use(plugin: (chai: Object, utils: Object) => void): void;
 
-  static isOk(object: mixed, message?: string): void;
-  static isNotOk(object: mixed, message?: string): void;
+  declare class assert {
+    static (expression: mixed, message?: string): void;
+    static fail(
+      actual: mixed,
+      expected: mixed,
+      message?: string,
+      operator?: string
+    ): void;
 
-  static equal(actual: mixed, expected: mixed, message?: string): void;
-  static notEqual(actual: mixed, expected: mixed, message?: string): void;
+    static isOk(object: mixed, message?: string): void;
+    static isNotOk(object: mixed, message?: string): void;
 
-  static strictEqual(act: mixed, exp: mixed, msg?: string): void;
-  static notStrictEqual(act: mixed, exp: mixed, msg?: string): void;
+    static equal(actual: mixed, expected: mixed, message?: string): void;
+    static notEqual(actual: mixed, expected: mixed, message?: string): void;
 
-  static deepEqual(act: mixed, exp: mixed, msg?: string): void;
-  static notDeepEqual(act: mixed, exp: mixed, msg?: string): void;
+    static strictEqual(act: mixed, exp: mixed, msg?: string): void;
+    static notStrictEqual(act: mixed, exp: mixed, msg?: string): void;
 
-  static ok(val: mixed, msg?: string): void;
-  static isTrue(val: mixed, msg?: string): void;
-  static isNotTrue(val: mixed, msg?: string): void;
-  static isFalse(val: mixed, msg?: string): void;
-  static isNotFalse(val: mixed, msg?: string): void;
+    static deepEqual(act: mixed, exp: mixed, msg?: string): void;
+    static notDeepEqual(act: mixed, exp: mixed, msg?: string): void;
 
-  static isNull(val: mixed, msg?: string): void;
-  static isNotNull(val: mixed, msg?: string): void;
+    static ok(val: mixed, msg?: string): void;
+    static isTrue(val: mixed, msg?: string): void;
+    static isNotTrue(val: mixed, msg?: string): void;
+    static isFalse(val: mixed, msg?: string): void;
+    static isNotFalse(val: mixed, msg?: string): void;
 
-  static isUndefined(val: mixed, msg?: string): void;
-  static isDefined(val: mixed, msg?: string): void;
+    static isNull(val: mixed, msg?: string): void;
+    static isNotNull(val: mixed, msg?: string): void;
 
-  static isNaN(val: mixed, msg?: string): void;
-  static isNotNaN(val: mixed, msg?: string): void;
+    static isUndefined(val: mixed, msg?: string): void;
+    static isDefined(val: mixed, msg?: string): void;
 
-  static isAbove(val: number, abv: number, msg?: string): void;
-  static isBelow(val: number, blw: number, msg?: string): void;
+    static isNaN(val: mixed, msg?: string): void;
+    static isNotNaN(val: mixed, msg?: string): void;
 
-  static isAtMost(val: number, atmst: number, msg?: string): void;
-  static isAtLeast(val: number, atlst: number, msg?: string): void;
+    static isAbove(val: number, abv: number, msg?: string): void;
+    static isBelow(val: number, blw: number, msg?: string): void;
 
-  static isFunction(val: mixed, msg?: string): void;
-  static isNotFunction(val: mixed, msg?: string): void;
+    static isAtMost(val: number, atmst: number, msg?: string): void;
+    static isAtLeast(val: number, atlst: number, msg?: string): void;
 
-  static isObject(val: mixed, msg?: string): void;
-  static isNotObject(val: mixed, msg?: string): void;
+    static isFunction(val: mixed, msg?: string): void;
+    static isNotFunction(val: mixed, msg?: string): void;
 
-  static isArray(val: mixed, msg?: string): void;
-  static isNotArray(val: mixed, msg?: string): void;
+    static isObject(val: mixed, msg?: string): void;
+    static isNotObject(val: mixed, msg?: string): void;
 
-  static isString(val: mixed, msg?: string): void;
-  static isNotString(val: mixed, msg?: string): void;
+    static isArray(val: mixed, msg?: string): void;
+    static isNotArray(val: mixed, msg?: string): void;
 
-  static isNumber(val: mixed, msg?: string): void;
-  static isNotNumber(val: mixed, msg?: string): void;
+    static isString(val: mixed, msg?: string): void;
+    static isNotString(val: mixed, msg?: string): void;
 
-  static isBoolean(val: mixed, msg?: string): void;
-  static isNotBoolean(val: mixed, msg?: string): void;
+    static isNumber(val: mixed, msg?: string): void;
+    static isNotNumber(val: mixed, msg?: string): void;
 
-  static typeOf(val: mixed, type: string, msg?: string): void;
-  static notTypeOf(val: mixed, type: string, msg?: string): void;
+    static isBoolean(val: mixed, msg?: string): void;
+    static isNotBoolean(val: mixed, msg?: string): void;
 
-  static instanceOf(val: mixed, constructor: Function, msg?: string): void;
-  static notInstanceOf(val: mixed, constructor: Function, msg?: string): void;
+    static typeOf(val: mixed, type: string, msg?: string): void;
+    static notTypeOf(val: mixed, type: string, msg?: string): void;
 
-  static include(exp: string, inc: mixed, msg?: string): void;
-  static include<T>(exp: Array<T>, inc: T, msg?: string): void;
+    static instanceOf(val: mixed, constructor: Function, msg?: string): void;
+    static notInstanceOf(val: mixed, constructor: Function, msg?: string): void;
 
-  static notInclude(exp: string, inc: mixed, msg?: string): void;
-  static notInclude<T>(exp: Array<T>, inc: T, msg?: string): void;
+    static include(exp: string, inc: mixed, msg?: string): void;
+    static include<T>(exp: Array<T>, inc: T, msg?: string): void;
 
-  static match(exp: mixed, re: RegExp, msg?: string): void;
-  static notMatch(exp: mixed, re: RegExp, msg?: string): void;
+    static notInclude(exp: string, inc: mixed, msg?: string): void;
+    static notInclude<T>(exp: Array<T>, inc: T, msg?: string): void;
 
-  static property(obj: Object, prop: string, msg?: string): void;
-  static notProperty(obj: Object, prop: string, msg?: string): void;
-  static deepProperty(obj: Object, prop: string, msg?: string): void;
-  static notDeepProperty(obj: Object, prop: string, msg?: string): void;
+    static match(exp: mixed, re: RegExp, msg?: string): void;
+    static notMatch(exp: mixed, re: RegExp, msg?: string): void;
 
-  static propertyVal(
-    obj: Object,
-    prop: string,
-    val: mixed,
-    msg?: string
-  ): void;
-  static propertyNotVal(
-    obj: Object,
-    prop: string,
-    val: mixed,
-    msg?: string
-  ): void;
+    static property(obj: Object, prop: string, msg?: string): void;
+    static notProperty(obj: Object, prop: string, msg?: string): void;
+    static deepProperty(obj: Object, prop: string, msg?: string): void;
+    static notDeepProperty(obj: Object, prop: string, msg?: string): void;
 
-  static deepPropertyVal(
-    obj: Object,
-    prop: string,
-    val: mixed,
-    msg?: string
-  ): void;
-  static deepPropertyNotVal(
-    obj: Object,
-    prop: string,
-    val: mixed,
-    msg?: string
-  ): void;
+    static propertyVal(
+      obj: Object,
+      prop: string,
+      val: mixed,
+      msg?: string
+    ): void;
+    static propertyNotVal(
+      obj: Object,
+      prop: string,
+      val: mixed,
+      msg?: string
+    ): void;
 
-  static lengthOf(exp: mixed, len: number, msg?: string): void;
+    static deepPropertyVal(
+      obj: Object,
+      prop: string,
+      val: mixed,
+      msg?: string
+    ): void;
+    static deepPropertyNotVal(
+      obj: Object,
+      prop: string,
+      val: mixed,
+      msg?: string
+    ): void;
 
-  static throws<E>(
-    func: () => any,
-    err?: Class<E> | Error | RegExp | string,
-    errorMsgMatcher?: string | RegExp,
-    msg?: string
-  ): void;
-  static doesNotThrow<E>(
-    func: () => any,
-    err?: Class<E> | Error | RegExp | string,
-    errorMsgMatcher?: string | RegExp,
-    msg?: string
-  ): void;
+    static lengthOf(exp: mixed, len: number, msg?: string): void;
 
-  static closeTo(
-    actual: number,
-    expected: number,
-    delta: number,
-    msg?: string
-  ): void;
-  static approximately(
-    actual: number,
-    expected: number,
-    delta: number,
-    msg?: string
-  ): void;
+    static throws<E>(
+      func: () => any,
+      err?: Class<E> | Error | RegExp | string,
+      errorMsgMatcher?: string | RegExp,
+      msg?: string
+    ): void;
+    static doesNotThrow<E>(
+      func: () => any,
+      err?: Class<E> | Error | RegExp | string,
+      errorMsgMatcher?: string | RegExp,
+      msg?: string
+    ): void;
 
-  // chai-immutable
-  static sizeOf(val: mixed, length: number): void;
+    static closeTo(
+      actual: number,
+      expected: number,
+      delta: number,
+      msg?: string
+    ): void;
+    static approximately(
+      actual: number,
+      expected: number,
+      delta: number,
+      msg?: string
+    ): void;
+
+    // chai-immutable
+    static sizeOf(val: mixed, length: number): void;
+  }
+
+  declare var config: {
+    includeStack: boolean,
+    showDiff: boolean,
+    truncateThreshold: number
+  };
 }
-
-declare var config: {
-  includeStack: boolean,
-  showDiff: boolean,
-  truncateThreshold: number
-};
 
 // ------------------------------
 // sinon


### PR DESCRIPTION
Previously we were exporting some stuff we don't actually expose in
`lib/index.js` (e.g. `config`, `use`) and weren't exposing `chai`, which
we recently started exporting. This should fix both.

Pivotal Story: [#156278303](https://www.pivotaltracker.com/story/show/156278303)