### PR TITLE
license as MIT and add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Good Eggs Code of Conduct v0.1.0
+
+This Code of Conduct governs how we behave in any forum and whenever we will be judged by our actions. We expect it to be honored by everyone who represents the [Good Eggs Open Source](https://bites.goodeggs.com) community officially or informally, claims affiliation with the project or participates directly.
+
+We strive to:
+
+- **Be open**: We invite anybody, from any company, to participate in any aspect of our projects. Our community is open, and any responsibility can be carried by any contributor who demonstrates the required capacity and competence.
+- **Be empathetic**: We work together to resolve conflict, assume good intentions and do our best to act in an empathic fashion. We don't allow frustration to turn into a personal attack. A community where people feel uncomfortable or threatened is not a productive one.
+- **Be collaborative**: Collaboration reduces redundancy and improves the quality of our work. We prefer to work transparently and involve interested parties as early as possible. Wherever possible, we work closely with upstream projects and others in the free software community to coordinate our efforts.
+- **Be pragmatic**: Nobody knows everything, Asking questions early avoids many problems later, so questions are encouraged, though they may be directed to the appropriate forum. Those who are asked should be responsive and helpful.
+- **Step down considerately**: Members of every project come and go. When somebody leaves or disengages from the project they should tell people they are leaving and take the proper steps to ensure that others can pick up where they left off.
+
+This code is not exhaustive or complete. It serves to distill our common understanding of a collaborative, shared environment and goals. We expect it to be followed in spirit as much as in the letter.
+
+## Diversity Statement
+
+We encourage participation by everyone. We are committed to being a community that everyone feels good about joining. Although we may not be able to satisfy everyone, we will always work to treat everyone well.
+
+Standards for behavior in the Good Eggs Open Source community are detailed in the Code of Conduct above. We expect participants in our community to meet these standards in all their interactions and to help others to do so as well.
+
+Whenever any participant has made a mistake, we expect them to take responsibility for it. If someone has been harmed or offended, it is our responsibility to listen carefully and respectfully, and do our best to right the wrong.
+
+Although this list cannot be exhaustive, we explicitly honor diversity in age, culture, ethnicity, genotype, gender identity or expression, language, national origin, neurotype, phenotype, political beliefs, profession, race, religion, sexual orientation, socioeconomic status, subculture and technical ability.
+
+## Reporting Issues
+
+It's first recommend you speak with respective project leads and committers about the issue.
+
+If that doesn't work:
+
+- You can report any code of conduct compliance issues by opening an issue in this repository
+- If you prefer a more discreet route, please email [open-source@goodeggs.com](open-source@goodeggs.com)
+
+## Credit (and copyright information)
+
+The wording of this code of conduct and diversity statement was heavily borrowed from work by the [Twitter](https://github.com/twitter/code-of-conduct), [Python](http://www.python.org/community/diversity), [Ubuntu](http://www.ubuntu.com/about/about-ubuntu/conduct) and [Mozilla](https://wiki.mozilla.org/Code_of_Conduct/Draft) communities. It is licensed under a [Creative Commons Attribution 3.0 Unported License](http://creativecommons.org/licenses/by/3.0/)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Good Eggs Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Goodeggs tests use [chai](http://chaijs.com/), with a bunch of plugins ready for
 
 ## Contributing
 
+Please follow our [Code of Conduct](CODE_OF_CONDUCT.md) when contributing to this project.
+
 ```
 yarn install
 yarn test
@@ -27,3 +29,7 @@ Remember to update the [changelog](CHANGELOG.md)!
 ```
 yarn version
 ```
+
+## License
+
+[MIT](License.md)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "6.5.3",
   "description": "Basic setup used for all goodeggs tests.",
   "author": "Good Eggs Inc.",
-  "license": "UNLICENSED",
+  "license": "MIT",
   "main": "lib/index.js",
   "bin": {
     "runtest": "./runtest.sh"


### PR DESCRIPTION
I believe this is our default stance on open source, especially as we already [publish this to the public npmjs.org repository](https://github.com/goodeggs/goodeggs-test-helpers/blob/license-as-open-source/package.json#L16) and depend upon it in our other open source libraries e.g. [json-fetch](https://github.com/goodeggs/json-fetch/pull/175/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2L46)