### PR TITLE
ci: fix NPM registry config

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,1 @@
-_auth = ${NPM_AUTH}
-always-auth = true
-strict-ssl = true
 registry = https://registry.npmjs.org/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,10 @@ before_install:
 install: yarn install
 script: yarn run test
 deploy:
-  provider: script
-  script: yarn publish
+  provider: npm
+  email: open-source@goodeggs.com
+  api_token:
+    secure: "pLrZd5KVghhrYpiEZhyIm/WFCNNriNoxTgmvSxHuTZl336ggbgwxDGsWcj3Hpwb/S+lIDEyvjW8c5Qv61f/mT+mw0nojoLs9fkYfZgoPaKlVE69LKUSFAWFQIFynbX4F6/TnnbPNYJNwDlQJNy3DmLR5L1dF2xCFvlOsVJuxpCkr5oF/zS7BJE2CuznHNTiUscTMqk4IS2ZTLYLo0SsJywOSa30QvmXCoxOhWgB/26itnzT0VoyL3BLC88MhsHOTrj25mb+BAeZ4Hg6XIetNJdL756mpW/zNdXLslPekQhFSzySN86ep/+b2nhG7QhMTw5ZmBO4kFT4vYlFXNzUfKHJOxk5QL0VcuFV8yBaVITyYDmafiPjlyDrlC5JXm2Mdu3aygbm5ZnMI4i2Qw3QGhXLFLK/6qlFSWoc5yiifqwm+BtFGg7nHE9PqLeS61WWJM0pD0VJOXB8jxCJ33Ot4cg899LxkS9jrE6iXwYhy/cXrDUCz61gkPhZvx7vidK4sgFJcndP8kSHb1SBilzHx7U2rG4aIQ6w2wNavj57tKE/ItyY7SrJNpVCVdLG7rUbj6YfH9vHIIxSXBlo+fUri/zbicCg9LslDy1F/9nhZQnTMa5mKdKARhLfqVPZyW5MUS7kNxNx1ls4SMHOj1aN/mpKiBPjQ0TKHZ5HOOSYBIKk="
   skip_cleanup: true
   on:
     tags: true

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Goodeggs Test Helpers
+# Good Eggs Test Helpers
 
 [![Build Status](https://travis-ci.org/goodeggs/goodeggs-test-helpers.svg?branch=master)](https://travis-ci.org/goodeggs/goodeggs-test-helpers)
 
@@ -6,11 +6,11 @@ Basic setup used for all Good Eggs tests.
 
 ## Test structure
 
-Goodeggs tests use the BDD testing DSL from [mocha](https://mochajs.org/), with a few extras.
+Good Eggs tests use the BDD testing DSL from [mocha](https://mochajs.org/), with a few extras.
 
 ## Assertions
 
-Goodeggs tests use [chai](http://chaijs.com/), with a bunch of plugins ready for you.
+Good Eggs tests use [chai](http://chaijs.com/), with a bunch of plugins ready for you.
 
 ## Contributing
 
@@ -21,13 +21,15 @@ yarn install
 yarn test
 ```
 
-## Deploying a new version
+## Releasing
 
-This module is automatically deployed when a version tag bump is detected by travis.
-Remember to update the [changelog](CHANGELOG.md)!
+To release a new version of this module, use yarn to bump the version
+in `package.json` and create a git tag, then push. This will automatically
+get published to the NPM registry via CI.
 
-```
-yarn version
+```sh
+yarn version --new-version=<major|minor|patch|premajor|preminor|prepatch>
+git push --follow-tags
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "@goodeggs/tsconfig": "^1.0.0",
     "@types/bunyan": "^1.8.6",
     "@types/mocha": "^8.2.0",
-    "@typescript-eslint/parser": "^4.14.2",
     "bunyan": "1.8.12",
     "leasot": "^9.1.0",
     "mocha": "^6.2.3",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "always-auth": true
+    "access": "public"
   },
   "engines": {
     "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-test-helpers",
-  "version": "8.0.0",
+  "version": "8.0.1",
   "description": "Basic setup used for all goodeggs tests.",
   "author": "Good Eggs Inc.",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1239,7 +1239,7 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^4.12.0", "@typescript-eslint/parser@^4.14.2":
+"@typescript-eslint/parser@^4.12.0":
   version "4.14.2"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.14.2.tgz#31e216e4baab678a56e539f9db9862e2542c98d0"
   dependencies:


### PR DESCRIPTION
Publish from CI has been broken for a while in this repo, e.g. https://travis-ci.com/github/goodeggs/goodeggs-test-helpers/builds/216445288.

We recently made some changes in https://github.com/goodeggs/goodeggs-test-helpers/pull/606, but these didn't get published.

I just reconfigured the repo per https://goodeggs.atlassian.net/wiki/spaces/ENG/pages/459833453/Using+NPM+and+Yarn#How-to-configure-a-public-module. I published a patch and it worked: https://travis-ci.com/github/goodeggs/goodeggs-test-helpers/builds/216452436.

(I removed an unused dependency I noticed while I was here.)