### PR TITLE
types: re-export sinon SinonStubbedInstance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-test-helpers",
-  "version": "8.1.0",
+  "version": "8.2.0",
   "description": "Basic setup used for all goodeggs tests.",
   "author": "Good Eggs Inc.",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
   SinonMock,
   SinonFakeTimers,
   SinonSandbox,
+  SinonStubbedInstance,
 } from './use_sinon_sandbox';
 
 const {expect} = chai;

--- a/src/use_sinon_sandbox.ts
+++ b/src/use_sinon_sandbox.ts
@@ -5,7 +5,15 @@ import {Logger} from './create_logger_stub';
 
 // Re-export these so that consumers don't need to install @types/sinon and this helper stays well
 // encapsulated.
-export {SinonStub, SinonSpy, SinonFake, SinonMock, SinonFakeTimers, SinonSandbox} from 'sinon';
+export {
+  SinonStub,
+  SinonSpy,
+  SinonFake,
+  SinonMock,
+  SinonFakeTimers,
+  SinonSandbox,
+  SinonStubbedInstance,
+} from 'sinon';
 
 interface StubLoggerReturn {
   trace: SinonStub;


### PR DESCRIPTION
We haven't really used `createStubInstance()` historically, but we want to introduce this pattern in https://github.com/goodeggs/catalog-api/pull/3725, so let's re-export the type.

# To Do

- [x] push a minor version