### PR TITLE
Typescript type for shared stubbed methods - 176894276

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-test-helpers",
-  "version": "8.2.0",
+  "version": "8.3.0",
   "description": "Basic setup used for all goodeggs tests.",
   "author": "Good Eggs Inc.",
   "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export {
   SinonFakeTimers,
   SinonSandbox,
   SinonStubbedInstance,
+  MethodStub,
 } from './use_sinon_sandbox';
 
 const {expect} = chai;

--- a/src/use_sinon_sandbox.ts
+++ b/src/use_sinon_sandbox.ts
@@ -15,6 +15,9 @@ export {
   SinonStubbedInstance,
 } from 'sinon';
 
+/**
+ * @description useful type when we need to share stubbed methods in our tests
+ */
 export type MethodStub<T extends (...args: unknown[]) => unknown> = SinonStub<
   Parameters<T>,
   ReturnType<T>

--- a/src/use_sinon_sandbox.ts
+++ b/src/use_sinon_sandbox.ts
@@ -15,6 +15,11 @@ export {
   SinonStubbedInstance,
 } from 'sinon';
 
+export type MethodStub<T extends (...args: unknown[]) => unknown> = SinonStub<
+  Parameters<T>,
+  ReturnType<T>
+>;
+
 interface StubLoggerReturn {
   trace: SinonStub;
   debug: SinonStub;


### PR DESCRIPTION
## Background

When we need to create a shared stub between many tests, we need to define the TS type in our declaration.

```ts
  let fetchStub: SinonStub<Parameters<typeof global.fetch>, ReturnType<typeof global.fetch>>;
  beforeEach('stub global fetch', function () {
    fetchStub = sandbox.stub(global, 'fetch')
  });
```
To simplify, we can create a new type using a Generic Type

 ## To Do

- [x] publish minor version

[#176894276]